### PR TITLE
Issue #14: Make Cids serializable by exporting their fields.

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -29,24 +29,24 @@ const (
 
 func NewCidV0(h mh.Multihash) *Cid {
 	return &Cid{
-		version: 0,
-		codec:   DagProtobuf,
-		hash:    h,
+		Version: 0,
+		Codec:   DagProtobuf,
+		MHash:   h,
 	}
 }
 
 func NewCidV1(c uint64, h mh.Multihash) *Cid {
 	return &Cid{
-		version: 1,
-		codec:   c,
-		hash:    h,
+		Version: 1,
+		Codec:   c,
+		MHash:   h,
 	}
 }
 
 type Cid struct {
-	version uint64
-	codec   uint64
-	hash    mh.Multihash
+	Version uint64
+	Codec   uint64
+	MHash   mh.Multihash
 }
 
 func Parse(v interface{}) (*Cid, error) {
@@ -114,9 +114,9 @@ func Cast(data []byte) (*Cid, error) {
 		}
 
 		return &Cid{
-			codec:   DagProtobuf,
-			version: 0,
-			hash:    h,
+			Codec:   DagProtobuf,
+			Version: 0,
+			MHash:   h,
 		}, nil
 	}
 
@@ -141,20 +141,20 @@ func Cast(data []byte) (*Cid, error) {
 	}
 
 	return &Cid{
-		version: vers,
-		codec:   codec,
-		hash:    h,
+		Version: vers,
+		Codec:   codec,
+		MHash:   h,
 	}, nil
 }
 
 func (c *Cid) Type() uint64 {
-	return c.codec
+	return c.Codec
 }
 
 func (c *Cid) String() string {
-	switch c.version {
+	switch c.Version {
 	case 0:
-		return c.hash.B58String()
+		return c.MHash.B58String()
 	case 1:
 		mbstr, err := mbase.Encode(mbase.Base58BTC, c.bytesV1())
 		if err != nil {
@@ -168,11 +168,11 @@ func (c *Cid) String() string {
 }
 
 func (c *Cid) Hash() mh.Multihash {
-	return c.hash
+	return c.MHash
 }
 
 func (c *Cid) Bytes() []byte {
-	switch c.version {
+	switch c.Version {
 	case 0:
 		return c.bytesV0()
 	case 1:
@@ -183,26 +183,26 @@ func (c *Cid) Bytes() []byte {
 }
 
 func (c *Cid) bytesV0() []byte {
-	return []byte(c.hash)
+	return []byte(c.MHash)
 }
 
 func (c *Cid) bytesV1() []byte {
 	// two 8 bytes (max) numbers plus hash
-	buf := make([]byte, 2*binary.MaxVarintLen64+len(c.hash))
-	n := binary.PutUvarint(buf, c.version)
-	n += binary.PutUvarint(buf[n:], c.codec)
-	cn := copy(buf[n:], c.hash)
-	if cn != len(c.hash) {
+	buf := make([]byte, 2*binary.MaxVarintLen64+len(c.MHash))
+	n := binary.PutUvarint(buf, c.Version)
+	n += binary.PutUvarint(buf[n:], c.Codec)
+	cn := copy(buf[n:], c.MHash)
+	if cn != len(c.MHash) {
 		panic("copy hash length is inconsistent")
 	}
 
-	return buf[:n+len(c.hash)]
+	return buf[:n+len(c.MHash)]
 }
 
 func (c *Cid) Equals(o *Cid) bool {
-	return c.codec == o.codec &&
-		c.version == o.version &&
-		bytes.Equal(c.hash, o.hash)
+	return c.Codec == o.Codec &&
+		c.Version == o.Version &&
+		bytes.Equal(c.MHash, o.MHash)
 }
 
 func (c *Cid) UnmarshalJSON(b []byte) error {
@@ -214,9 +214,9 @@ func (c *Cid) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	c.version = out.version
-	c.hash = out.hash
-	c.codec = out.codec
+	c.Version = out.Version
+	c.MHash = out.MHash
+	c.Codec = out.Codec
 	return nil
 }
 
@@ -235,12 +235,12 @@ func (c *Cid) Loggable() map[string]interface{} {
 }
 
 func (c *Cid) Prefix() Prefix {
-	dec, _ := mh.Decode(c.hash) // assuming we got a valid multiaddr, this will not error
+	dec, _ := mh.Decode(c.MHash) // assuming we got a valid multiaddr, this will not error
 	return Prefix{
-		MhType:   dec.Code,
+		MhType:   int(dec.Code),
 		MhLength: dec.Length,
-		Version:  c.version,
-		Codec:    c.codec,
+		Version:  c.Version,
+		Codec:    c.Codec,
 	}
 }
 
@@ -253,7 +253,7 @@ type Prefix struct {
 }
 
 func (p Prefix) Sum(data []byte) (*Cid, error) {
-	hash, err := mh.Sum(data, p.MhType, p.MhLength)
+	hash, err := mh.Sum(data, uint64(p.MhType), p.MhLength)
 	if err != nil {
 		return nil, err
 	}

--- a/cid.go
+++ b/cid.go
@@ -253,7 +253,7 @@ type Prefix struct {
 }
 
 func (p Prefix) Sum(data []byte) (*Cid, error) {
-	hash, err := mh.Sum(data, uint64(p.MhType), p.MhLength)
+	hash, err := mh.Sum(data, p.MhType, p.MhLength)
 	if err != nil {
 		return nil, err
 	}

--- a/cid_test.go
+++ b/cid_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 func assertEqual(t *testing.T, a, b *Cid) {
-	if a.codec != b.codec {
+	if a.Codec != b.Codec {
 		t.Fatal("mismatch on type")
 	}
 
-	if a.version != b.version {
+	if a.Version != b.Version {
 		t.Fatal("mismatch on version")
 	}
 
-	if !bytes.Equal(a.hash, b.hash) {
+	if !bytes.Equal(a.MHash, b.MHash) {
 		t.Fatal("multihash mismatch")
 	}
 }
@@ -31,9 +31,9 @@ func TestBasicMarshaling(t *testing.T) {
 	}
 
 	cid := &Cid{
-		codec:   7,
-		version: 1,
-		hash:    h,
+		Codec:   7,
+		Version: 1,
+		MHash:   h,
 	}
 
 	data := cid.Bytes()
@@ -69,11 +69,11 @@ func TestV0Handling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cid.version != 0 {
+	if cid.Version != 0 {
 		t.Fatal("should have gotten version 0 cid")
 	}
 
-	if cid.hash.B58String() != old {
+	if cid.MHash.B58String() != old {
 		t.Fatal("marshaling roundtrip failed")
 	}
 
@@ -124,7 +124,7 @@ func Test16BytesVarint(t *testing.T) {
 	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
 	c := NewCidV1(DagCBOR, hash)
 
-	c.codec = 1 << 63
+	c.Codec = 1 << 63
 	_ = c.Bytes()
 }
 
@@ -167,8 +167,8 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if cid.version != 0 {
-			return fmt.Errorf("expected version 0, got %s", string(cid.version))
+		if cid.Version != 0 {
+			return fmt.Errorf("expected version 0, got %s", string(cid.Version))
 		}
 		actual := cid.Hash().B58String()
 		if actual != expected {


### PR DESCRIPTION
This is very useful when sending Cids as part of RPCs.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>