### PR TITLE
Added map of string to codecs

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -80,7 +80,7 @@ const (
 )
 
 // Codecs maps the name of a codec to its type
-var Codecs = map[string]byte{
+var Codecs = map[string]uint64{
 	"v0":                   DagProtobuf,
 	"raw":                  Raw,
 	"protobuf":             DagProtobuf,

--- a/cid.go
+++ b/cid.go
@@ -79,6 +79,28 @@ const (
 	ZcashTx            = 0xc1
 )
 
+// Codecs maps the name of a codec to its type
+var Codecs = map[string]byte{
+	"v0":                   DagProtobuf,
+	"raw":                  Raw,
+	"protobuf":             DagProtobuf,
+	"cbor":                 DagCBOR,
+	"git-raw":              GitRaw,
+	"eth-block":            EthBlock,
+	"eth-block-list":       EthBlockList,
+	"eth-tx-trie":          EthTxTrie,
+	"eth-tx":               EthTx,
+	"eth-tx-receipt-trie":  EthTxReceiptTrie,
+	"eth-tx-receipt":       EthTxReceipt,
+	"eth-state-trie":       EthStateTrie,
+	"eth-account-snapshot": EthAccountSnapshot,
+	"eth-storage-trie":     EthStorageTrie,
+	"bitcoin-block":        BitcoinBlock,
+	"bitcoin-tx":           BitcoinTx,
+	"zcash-block":          ZcashBlock,
+	"zcash-tx":             ZcashTx,
+}
+
 // NewCidV0 returns a Cid-wrapped multihash.
 // They exist to allow IPFS to work with Cids while keeping
 // compatibility with the plain-multihash format used used in IPFS.

--- a/cid_test.go
+++ b/cid_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 // Copying the "silly test" idea from
-// makes it so changing the table accidentally has to happen twice.
 // https://github.com/multiformats/go-multihash/blob/7aa9f26a231c6f34f4e9fad52bf580fd36627285/multihash_test.go#L13
-var tCodes = map[byte]string{
+// Makes it so changing the table accidentally has to happen twice.
+var tCodecs = map[byte]string{
 	Raw:                "raw",
 	DagProtobuf:        "protobuf",
 	DagCBOR:            "cbor",
@@ -50,7 +50,11 @@ func assertEqual(t *testing.T, a, b *Cid) {
 }
 
 func TestTable(t *testing.T) {
-	for k, v := range tCodes {
+	if len(tCodecs) != len(Codecs)-1 {
+		t.Errorf("Item count mismatch in the Table of Codec. Should be %d, got %d", len(tCodecs)+1, len(Codecs))
+	}
+
+	for k, v := range tCodecs {
 		if Codecs[v] != k {
 			t.Errorf("Table mismatch: 0x%x %s", k, v)
 		}

--- a/cid_test.go
+++ b/cid_test.go
@@ -15,7 +15,7 @@ import (
 // Copying the "silly test" idea from
 // https://github.com/multiformats/go-multihash/blob/7aa9f26a231c6f34f4e9fad52bf580fd36627285/multihash_test.go#L13
 // Makes it so changing the table accidentally has to happen twice.
-var tCodecs = map[byte]string{
+var tCodecs = map[uint64]string{
 	Raw:                "raw",
 	DagProtobuf:        "protobuf",
 	DagCBOR:            "cbor",

--- a/cid_test.go
+++ b/cid_test.go
@@ -12,6 +12,29 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
+// Copying the "silly test" idea from
+// makes it so changing the table accidentally has to happen twice.
+// https://github.com/multiformats/go-multihash/blob/7aa9f26a231c6f34f4e9fad52bf580fd36627285/multihash_test.go#L13
+var tCodes = map[byte]string{
+	Raw:                "raw",
+	DagProtobuf:        "protobuf",
+	DagCBOR:            "cbor",
+	GitRaw:             "git-raw",
+	EthBlock:           "eth-block",
+	EthBlockList:       "eth-block-list",
+	EthTxTrie:          "eth-tx-trie",
+	EthTx:              "eth-tx",
+	EthTxReceiptTrie:   "eth-tx-receipt-trie",
+	EthTxReceipt:       "eth-tx-receipt",
+	EthStateTrie:       "eth-state-trie",
+	EthAccountSnapshot: "eth-account-snapshot",
+	EthStorageTrie:     "eth-storage-trie",
+	BitcoinBlock:       "bitcoin-block",
+	BitcoinTx:          "bitcoin-tx",
+	ZcashBlock:         "zcash-block",
+	ZcashTx:            "zcash-tx",
+}
+
 func assertEqual(t *testing.T, a, b *Cid) {
 	if a.codec != b.codec {
 		t.Fatal("mismatch on type")
@@ -23,6 +46,22 @@ func assertEqual(t *testing.T, a, b *Cid) {
 
 	if !bytes.Equal(a.hash, b.hash) {
 		t.Fatal("multihash mismatch")
+	}
+}
+
+func TestTable(t *testing.T) {
+	for k, v := range tCodes {
+		if Codecs[v] != k {
+			t.Errorf("Table mismatch: 0x%x %s", k, v)
+		}
+	}
+}
+
+// The table returns cid.DagProtobuf for "v0"
+// so we test it apart
+func TestTableForV0(t *testing.T) {
+	if Codecs["v0"] != DagProtobuf {
+		t.Error("Table mismatch: Codecs[\"v0\"] should resolve to DagProtobuf (0x70)")
 	}
 }
 
@@ -77,7 +116,7 @@ func TestBasesMarshaling(t *testing.T) {
 
 	assertEqual(t, cid, out)
 
-	testBases := []mbase.Encoding {
+	testBases := []mbase.Encoding{
 		mbase.Base16,
 		mbase.Base32,
 		mbase.Base32hex,


### PR DESCRIPTION
Example

```go
cid.Codecs["eth-block"] // Will evaluate to '\x90' (cid.EthBlock)
```

Very useful for `ipfs block put --format <format> --mhtype <mhtype> <object>`
