### PR TITLE
Fix StringOfBase to allow encoding CidV0 in alternative bases.

### DIFF
--- a/cid-fmt/main.go
+++ b/cid-fmt/main.go
@@ -37,8 +37,8 @@ const fmtRef = `
    %s cid string encoded in base %b without multibase prefix
    %P cid prefix: %v-%c-%h-%L
 
-(1) For CID version 0 the multibase must be base58btc and no prefix is
-used.  For Cid version 1 the multibase prefix is included.
+(1) If the CID version is 0 and the multibase is base58btc no prefix
+is used.  For all other cases the multibase prefix is included.
 `
 
 func main() {

--- a/cid.go
+++ b/cid.go
@@ -299,10 +299,11 @@ func (c *Cid) String() string {
 func (c *Cid) StringOfBase(base mbase.Encoding) (string, error) {
 	switch c.version {
 	case 0:
-		if base != mbase.Base58BTC {
-			return "", ErrInvalidEncoding
+		if base == mbase.Base58BTC {
+			return c.hash.B58String(), nil
+		} else {
+			return mbase.Encode(base, c.bytesV0())
 		}
-		return c.hash.B58String(), nil
 	case 1:
 		return mbase.Encode(base, c.bytesV1())
 	default:


### PR DESCRIPTION
See https://github.com/ipfs/go-cid/issues/34#issuecomment-325868148