### PR TITLE
support nil CIDs when checking equality

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -371,6 +371,12 @@ func (c *Cid) bytesV1() []byte {
 // In order for two Cids to be considered equal, the
 // Version, the Codec and the Multihash must match.
 func (c *Cid) Equals(o *Cid) bool {
+	if c == nil || o == nil {
+		return false
+	}
+	if c == o {
+		return true
+	}
 	return c.codec == o.codec &&
 		c.version == o.version &&
 		bytes.Equal(c.hash, o.hash)

--- a/cid_test.go
+++ b/cid_test.go
@@ -285,6 +285,17 @@ func Test16BytesVarint(t *testing.T) {
 	_ = c.Bytes()
 }
 
+func TestEqual(t *testing.T) {
+	data := []byte("this is some test content")
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	c := NewCidV1(DagCBOR, hash)
+
+	var cNil *Cid
+	if c.Equals(cNil) || cNil.Equals(c) || cNil.Equals(cNil) {
+		t.Fatal("expected nil CIDs to equal nothing")
+	}
+}
+
 func TestFuzzCid(t *testing.T) {
 	buf := make([]byte, 128)
 	for i := 0; i < 200; i++ {


### PR DESCRIPTION
Treat nil CIDs like NaN. They never equal anything.

(also, short-circuit equality check for self == self)