### PR TITLE
Tweak parameters of NewPrefix functions.

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -145,10 +145,10 @@ func NewCidV1(codecType uint64, mhash mh.Multihash) *Cid {
 }
 
 // NewPrefixV0 returns a CIDv0 prefix with the specified multihash type.
-func NewPrefixV0(mhType uint64) Prefix {
+func NewPrefixV0() Prefix {
 	return Prefix{
-		MhType:   mhType,
-		MhLength: mh.DefaultLengths[mhType],
+		MhType:   mh.SHA2_256,
+		MhLength: mh.DefaultLengths[mh.SHA2_256],
 		Version:  0,
 		Codec:    DagProtobuf,
 	}
@@ -156,10 +156,13 @@ func NewPrefixV0(mhType uint64) Prefix {
 
 // NewPrefixV1 returns a CIDv1 prefix with the specified codec and multihash
 // type.
-func NewPrefixV1(codecType uint64, mhType uint64) Prefix {
+func NewPrefixV1(codecType uint64, mhType uint64, mhLen int) Prefix {
+	if mhLen == -1 {
+		mhLen = mh.DefaultLengths[mhType]
+	}
 	return Prefix{
 		MhType:   mhType,
-		MhLength: mh.DefaultLengths[mhType],
+		MhLength: mhLen,
 		Version:  1,
 		Codec:    codecType,
 	}

--- a/cid_test.go
+++ b/cid_test.go
@@ -193,7 +193,7 @@ func TestNewPrefixV1(t *testing.T) {
 	data := []byte("this is some test content")
 
 	// Construct c1
-	prefix := NewPrefixV1(DagCBOR, mh.SHA2_256)
+	prefix := NewPrefixV1(DagCBOR, mh.SHA2_256, -1)
 	c1, err := prefix.Sum(data)
 	if err != nil {
 		t.Fatal(err)
@@ -222,7 +222,7 @@ func TestNewPrefixV0(t *testing.T) {
 	data := []byte("this is some test content")
 
 	// Construct c1
-	prefix := NewPrefixV0(mh.SHA2_256)
+	prefix := NewPrefixV0()
 	c1, err := prefix.Sum(data)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
I don't think these two functions are really used yet, so this shouldn't break anything.

`NewPrefixV0` doesn't take any parameters, since there is only one possible legal combination.  `NewCidV1` is expanded to also take the multihash length.  Even though the length 99% of the time will be `-1` it still makes sense to require it.  This gives the function the opportunity to convert the length value of `-1` to the default length.  The callee of the function is already likely to have the length value and needs to do something with it.  With out being able to pass it in the most logical think to do would be to set it afterwards, for example:
```
  func foo(..., mh uint64, mhlen int) { 
    prefix := cid.NewPrefixV1(..., mh)
    prefix.MhLength = mhlen
  }
```
which doesn't allow NewPrefix to set the value to the default length.

Closes #49.