### PR TITLE
proposal: Allow encoding CIDv0 in custom multibase

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -321,7 +321,7 @@ func (c *Cid) StringOfBase(base mbase.Encoding) (string, error) {
 	switch c.version {
 	case 0:
 		if base != mbase.Base58BTC {
-			return "", ErrInvalidEncoding
+			return mbase.Encode(base, c.bytesV1())
 		}
 		return c.hash.B58String(), nil
 	case 1:


### PR DESCRIPTION
This is basically the first step needed to be able to output base32 cidv0 hashes from go-ipfs, there is a lot more to do on the js, go and docs fronts. 

This code will output 'cid0.5' for cidv0s with encoding different than Base58 (multibase encoded cidv1 with version field set to 0), it's a rather horrible hack, but it does the trick, allowing us to use base32 cidv0 in go-ipfs without major changes.

We still need to check that this works with js-ipfs the same way it does here.

Example base32 cidv0 hash:
```
ipfs cat babybeifdmflkybo26fnmpxrcoakgaeax4yrt2kftctbcz3zz6uz3c5p3xy
```
