### PR TITLE
Add Decred codecs

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -77,6 +77,8 @@ const (
 	BitcoinTx          = 0xb1
 	ZcashBlock         = 0xc0
 	ZcashTx            = 0xc1
+	DecredBlock        = 0xe0
+	DecredTx           = 0xe1
 )
 
 // Codecs maps the name of a codec to its type
@@ -99,6 +101,8 @@ var Codecs = map[string]uint64{
 	"bitcoin-tx":           BitcoinTx,
 	"zcash-block":          ZcashBlock,
 	"zcash-tx":             ZcashTx,
+	"decred-block":         DecredBlock,
+	"decred-tx":            DecredTx,
 }
 
 // CodecToStr maps the numeric codec to its name
@@ -120,6 +124,8 @@ var CodecToStr = map[uint64]string{
 	BitcoinTx:          "bitcoin-tx",
 	ZcashBlock:         "zcash-block",
 	ZcashTx:            "zcash-tx",
+	DecredBlock:        "decred-block",
+	DecredTx:           "decred-tx",
 }
 
 // NewCidV0 returns a Cid-wrapped multihash.

--- a/cid_test.go
+++ b/cid_test.go
@@ -33,6 +33,8 @@ var tCodecs = map[uint64]string{
 	BitcoinTx:          "bitcoin-tx",
 	ZcashBlock:         "zcash-block",
 	ZcashTx:            "zcash-tx",
+	DecredBlock:        "decred-block",
+	DecredTx:           "decred-tx",
 }
 
 func assertEqual(t *testing.T, a, b *Cid) {


### PR DESCRIPTION
0xe0 and 0xe1 have been assigned to Decred block and tx in the
multicodecs table. https://github.com/multiformats/multicodec/pull/78

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>