### PR TITLE
Create a new Encode method that is like StringOfBase but never errors 

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -338,6 +338,18 @@ func (c *Cid) StringOfBase(base mbase.Encoding) (string, error) {
 	}
 }
 
+// Format return the string representation of a Cid
+func (c *Cid) Format(base mbase.Encoder) string {
+	switch c.version {
+	case 0:
+		return c.hash.B58String()
+	case 1:
+		return base.Encode(c.bytesV1())
+	default:
+		panic("not possible to reach this point")
+	}
+}
+
 // Hash returns the multihash contained by a Cid.
 func (c *Cid) Hash() mh.Multihash {
 	return c.hash

--- a/cid.go
+++ b/cid.go
@@ -339,7 +339,8 @@ func (c *Cid) StringOfBase(base mbase.Encoding) (string, error) {
 }
 
 // Encode return the string representation of a Cid in a given base
-// when applicable
+// when applicable.  Version 0 Cid's are always in Base58 as they do
+// not take a multibase prefix.
 func (c *Cid) Encode(base mbase.Encoder) string {
 	switch c.version {
 	case 0:

--- a/cid.go
+++ b/cid.go
@@ -338,8 +338,9 @@ func (c *Cid) StringOfBase(base mbase.Encoding) (string, error) {
 	}
 }
 
-// Format return the string representation of a Cid
-func (c *Cid) Format(base mbase.Encoder) string {
+// Encode return the string representation of a Cid in a given base
+// when applicable
+func (c *Cid) Encode(base mbase.Encoder) string {
 	switch c.version {
 	case 0:
 		return c.hash.B58String()

--- a/cid_test.go
+++ b/cid_test.go
@@ -153,11 +153,11 @@ func TestBasesMarshaling(t *testing.T) {
 
 		assertEqual(t, cid, out2)
 
-		prefix, err := mbase.NewEncoder(b)
+		encoder, err := mbase.NewEncoder(b)
 		if err != nil {
 			t.Fatal(err)
 		}
-		s2 := cid.Format(prefix)
+		s2 := cid.Encode(encoder)
 		if s != s2 {
 			t.Fatalf("'%s' != '%s'", s, s2)
 		}

--- a/cid_test.go
+++ b/cid_test.go
@@ -152,6 +152,15 @@ func TestBasesMarshaling(t *testing.T) {
 		}
 
 		assertEqual(t, cid, out2)
+
+		prefix, err := mbase.NewEncoder(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s2 := cid.Format(prefix)
+		if s != s2 {
+			t.Fatalf("'%s' != '%s'", s, s2)
+		}
 	}
 }
 

--- a/cid_test.go
+++ b/cid_test.go
@@ -190,6 +190,22 @@ func TestV0Handling(t *testing.T) {
 	if cid.String() != old {
 		t.Fatal("marshaling roundtrip failed")
 	}
+
+	new, err := cid.StringOfBase(mbase.Base58BTC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if new != old {
+		t.Fatal("StringOfBase roundtrip failed")
+	}
+
+	encoder, err := mbase.NewEncoder(mbase.Base58BTC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cid.Encode(encoder) != old {
+		t.Fatal("Encode roundtrip failed")
+	}
 }
 
 func TestV0ErrorCases(t *testing.T) {


### PR DESCRIPTION
The idea is that we can just replace calls to `String()` with `Encode(base)`.  For this to work we need a method that will return meaningful results for all CIDs and never errors.

Used by https://github.com/ipfs/go-ipfs/pull/5289.