### PR TITLE
Feature: support storing a value along with the Cid

### DIFF
--- a/set.go
+++ b/set.go
@@ -2,18 +2,25 @@ package cid
 
 // Set is a implementation of a set of Cids, that is, a structure
 // to which holds a single copy of every Cids that is added to it.
+// It also works with pairs formed by a Cid and a user provided arbitrary
+// value.
 type Set struct {
-	set map[string]struct{}
+	set map[string]interface{}
 }
 
 // NewSet initializes and returns a new Set.
 func NewSet() *Set {
-	return &Set{set: make(map[string]struct{})}
+	return &Set{set: make(map[string]interface{})}
 }
 
 // Add puts a Cid in the Set.
 func (s *Set) Add(c *Cid) {
-	s.set[string(c.Bytes())] = struct{}{}
+	s.AddPair(c, struct{}{})
+}
+
+// AddPair puts a Cid and a custom value in the Set.
+func (s *Set) AddPair(c *Cid, val interface{}) {
+	s.set[string(c.Bytes())] = val
 }
 
 // Has returns if the Set contains a given Cid.
@@ -45,20 +52,41 @@ func (s *Set) Keys() []*Cid {
 // Visit adds a Cid to the set only if it is
 // not in it already.
 func (s *Set) Visit(c *Cid) bool {
-	if !s.Has(c) {
-		s.Add(c)
-		return true
+	visitF := func(curVal, newVal interface{}) bool {
+		return false // never overwrite
 	}
 
+	return s.VisitPair(c, struct{}{}, visitF)
+}
+
+// VisitPair adds a pair to the set if the Cid is not already
+// in the set OR the provided visitF function returns true.
+// In other words, it replaces an existing pair if visitF returns true.
+func (s *Set) VisitPair(c *Cid, newVal interface{}, visitF func(curVal, newVal interface{}) bool) bool {
+	curVal, ok := s.set[string(c.Bytes())]
+	if !ok || visitF(curVal, newVal) {
+		s.AddPair(c, newVal)
+		return true
+	}
 	return false
+
 }
 
 // ForEach allows to run a custom function on each
 // Cid in the set.
 func (s *Set) ForEach(f func(c *Cid) error) error {
-	for cs := range s.set {
+	pairF := func(c *Cid, v interface{}) error {
+		return f(c)
+	}
+	return s.ForEachPair(pairF)
+}
+
+// ForEachPair allows to run a custom function on each
+// Pair in the set.
+func (s *Set) ForEachPair(f func(c *Cid, v interface{}) error) error {
+	for cs, v := range s.set {
 		c, _ := Cast([]byte(cs))
-		err := f(c)
+		err := f(c, v)
 		if err != nil {
 			return err
 		}

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,132 @@
+package cid
+
+import (
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	mh "github.com/multiformats/go-multihash"
+)
+
+func makeRandomCid(t *testing.T) *Cid {
+	p := make([]byte, 256)
+	_, err := rand.Read(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := mh.Sum(p, mh.SHA3, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cid := &Cid{
+		codec:   7,
+		version: 1,
+		hash:    h,
+	}
+
+	return cid
+}
+
+func TestSet(t *testing.T) {
+	cid := makeRandomCid(t)
+	cid2 := makeRandomCid(t)
+	s := NewSet()
+
+	s.Add(cid)
+
+	if !s.Has(cid) {
+		t.Error("should have the CID")
+	}
+
+	if s.Len() != 1 {
+		t.Error("should report 1 element")
+	}
+
+	keys := s.Keys()
+
+	if len(keys) != 1 || !keys[0].Equals(cid) {
+		t.Error("key should correspond to Cid")
+	}
+
+	if s.Visit(cid) {
+		t.Error("visit should return false")
+	}
+
+	foreach := []*Cid{}
+	foreachF := func(c *Cid) error {
+		foreach = append(foreach, c)
+		return nil
+	}
+
+	if err := s.ForEach(foreachF); err != nil {
+		t.Error(err)
+	}
+
+	if len(foreach) != 1 {
+		t.Error("ForEach should have visited 1 element")
+	}
+
+	foreachErr := func(c *Cid) error {
+		return errors.New("test")
+	}
+
+	if err := s.ForEach(foreachErr); err == nil {
+		t.Error("Should have returned an error")
+	}
+
+	if !s.Visit(cid2) {
+		t.Error("should have visited a new Cid")
+	}
+
+	if s.Len() != 2 {
+		t.Error("len should be 2 now")
+	}
+
+	s.Remove(cid2)
+
+	if s.Len() != 1 {
+		t.Error("len should be 1 now")
+	}
+}
+
+func TestSetPair(t *testing.T) {
+	cid := makeRandomCid(t)
+	cid2 := makeRandomCid(t)
+	s := NewSet()
+
+	visitF := func(curVal, newVal interface{}) bool {
+		return curVal.(int) < newVal.(int)
+	}
+
+	s.AddPair(cid, 10)
+	visited := s.VisitPair(cid, 5, visitF)
+	if visited {
+		t.Error("should not have visited the Cid since 5 <= 10")
+	}
+
+	visited = s.VisitPair(cid2, 3, visitF)
+	if !visited {
+		t.Error("should have visited a new value")
+	}
+
+	visited = s.VisitPair(cid, 11, visitF)
+	if !visited {
+		t.Error("should have visited because 10<11")
+	}
+
+	if s.Len() != 2 {
+		t.Error("set should have 2 entries")
+	}
+
+	sum := 0
+	forEachF := func(c *Cid, v interface{}) error {
+		sum += v.(int)
+		return nil
+	}
+	s.ForEachPair(forEachF)
+	if sum != 14 {
+		t.Error("items in set should total 3+11 = 14")
+	}
+}


### PR DESCRIPTION
This adds support for storing ordered-pairs (a tuple of 2 elements, being the
first one the Cid) in the set.

A VisitPair function allows the user to decide, based on the second element
of the pairs, when to replace the existing element on the set (as opposed to the `Visit()` function which only considers if it existed previously).

---

@Stebalien this should allow shortcutting branches when exploring with depth-limits in go-ipfs, by storing the depth and providing a custom visit function, without the need for a special set type or another library. The set works and can be used as before.