### PR TITLE
WIP: Make Cid an interface and change default representation to a String

### DIFF
--- a/cid-fmt/main.go
+++ b/cid-fmt/main.go
@@ -46,7 +46,7 @@ func main() {
 		usage()
 	}
 	newBase := mb.Encoding(-1)
-	var verConv func(cid *c.Cid) (*c.Cid, error)
+	var verConv func(cid c.Cid) (c.Cid, error)
 	args := os.Args[1:]
 outer:
 	for {
@@ -132,7 +132,7 @@ func errorMsg(fmtStr string, a ...interface{}) {
 	exitCode = 1
 }
 
-func decode(v string) (mb.Encoding, *c.Cid, error) {
+func decode(v string) (mb.Encoding, c.Cid, error) {
 	if len(v) < 2 {
 		return 0, nil, c.ErrCidTooShort
 	}
@@ -158,7 +158,7 @@ func decode(v string) (mb.Encoding, *c.Cid, error) {
 
 const ERR_STR = "!ERROR!"
 
-func fmtCid(fmtStr string, base mb.Encoding, cid *c.Cid) (string, error) {
+func fmtCid(fmtStr string, base mb.Encoding, cid c.Cid) (string, error) {
 	p := cid.Prefix()
 	out := new(bytes.Buffer)
 	var err error
@@ -265,13 +265,13 @@ func encode(base mb.Encoding, data []byte, strip bool) string {
 	return str
 }
 
-func toCidV0(cid *c.Cid) (*c.Cid, error) {
+func toCidV0(cid c.Cid) (c.Cid, error) {
 	if cid.Type() != c.DagProtobuf {
 		return nil, fmt.Errorf("can't convert non-protobuf nodes to cidv0")
 	}
 	return c.NewCidV0(cid.Hash()), nil
 }
 
-func toCidV1(cid *c.Cid) (*c.Cid, error) {
+func toCidV1(cid c.Cid) (c.Cid, error) {
 	return c.NewCidV1(cid.Type(), cid.Hash()), nil
 }

--- a/cid_test.go
+++ b/cid_test.go
@@ -37,16 +37,16 @@ var tCodecs = map[uint64]string{
 	DecredTx:           "decred-tx",
 }
 
-func assertEqual(t *testing.T, a, b *cid_) {
-	if a.codec != b.codec {
+func assertEqual(t *testing.T, a, b Cid) {
+	if a.Type() != b.Type() {
 		t.Fatal("mismatch on type")
 	}
 
-	if a.version != b.version {
+	if a.Version() != b.Version() {
 		t.Fatal("mismatch on version")
 	}
 
-	if !bytes.Equal(a.hash, b.hash) {
+	if !bytes.Equal(a.Hash(), b.Hash()) {
 		t.Fatal("multihash mismatch")
 	}
 }
@@ -77,11 +77,7 @@ func TestBasicMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cid := &cid_{
-		codec:   7,
-		version: 1,
-		hash:    h,
-	}
+	cid := NewCidV1(7, h)
 
 	data := cid.Bytes()
 
@@ -107,11 +103,7 @@ func TestBasesMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cid := &cid_{
-		codec:   7,
-		version: 1,
-		hash:    h,
-	}
+	cid := NewCidV1(7, h)
 
 	data := cid.Bytes()
 
@@ -170,11 +162,11 @@ func TestV0Handling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cid.version != 0 {
+	if cid.Version() != 0 {
 		t.Fatal("should have gotten version 0 cid")
 	}
 
-	if cid.hash.B58String() != old {
+	if cid.Hash().B58String() != old {
 		t.Fatal("marshaling roundtrip failed")
 	}
 
@@ -281,9 +273,7 @@ func TestPrefixRoundtrip(t *testing.T) {
 func Test16BytesVarint(t *testing.T) {
 	data := []byte("this is some test content")
 	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
-	c := NewCidV1(DagCBOR, hash)
-
-	c.codec = 1 << 63
+	c := NewCidV1(1 <<63, hash)
 	_ = c.Bytes()
 }
 
@@ -326,8 +316,8 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if cid.version != 0 {
-			return fmt.Errorf("expected version 0, got %s", string(cid.version))
+		if cid.Version() != 0 {
+			return fmt.Errorf("expected version 0, got %s", string(cid.Version()))
 		}
 		actual := cid.Hash().B58String()
 		if actual != expected {
@@ -376,7 +366,7 @@ func TestFromJson(t *testing.T) {
 	cval := "zb2rhhFAEMepUBbGyP1k8tGfz7BSciKXP6GHuUeUsJBaK6cqG"
 	jsoncid := []byte(`{"/":"` + cval + `"}`)
 	c := EmptyCid()
-	err := json.Unmarshal(jsoncid, &c)
+	err := json.Unmarshal(jsoncid, c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cid_test.go
+++ b/cid_test.go
@@ -37,7 +37,7 @@ var tCodecs = map[uint64]string{
 	DecredTx:           "decred-tx",
 }
 
-func assertEqual(t *testing.T, a, b *Cid) {
+func assertEqual(t *testing.T, a, b *cid_) {
 	if a.codec != b.codec {
 		t.Fatal("mismatch on type")
 	}
@@ -77,7 +77,7 @@ func TestBasicMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cid := &Cid{
+	cid := &cid_{
 		codec:   7,
 		version: 1,
 		hash:    h,
@@ -107,7 +107,7 @@ func TestBasesMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cid := &Cid{
+	cid := &cid_{
 		codec:   7,
 		version: 1,
 		hash:    h,
@@ -375,7 +375,7 @@ func ExampleDecode() {
 func TestFromJson(t *testing.T) {
 	cval := "zb2rhhFAEMepUBbGyP1k8tGfz7BSciKXP6GHuUeUsJBaK6cqG"
 	jsoncid := []byte(`{"/":"` + cval + `"}`)
-	var c Cid
+	c := EmptyCid()
 	err := json.Unmarshal(jsoncid, &c)
 	if err != nil {
 		t.Fatal(err)
@@ -392,25 +392,13 @@ func TestJsonRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify it works for a *Cid.
 	enc, err := json.Marshal(exp)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var actual Cid
-	err = json.Unmarshal(enc, &actual)
-	if !exp.Equals(&actual) {
-		t.Fatal("cids not equal for *Cid")
-	}
-
-	// Verify it works for a Cid.
-	enc, err = json.Marshal(*exp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var actual2 Cid
-	err = json.Unmarshal(enc, &actual2)
-	if !exp.Equals(&actual2) {
+	actual := EmptyCid()
+	err = json.Unmarshal(enc, actual)
+	if !exp.Equals(actual) {
 		t.Fatal("cids not equal for Cid")
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmexBtiTTEwwn42Yi6ouKt6VqzpA6wjJgiW1oh9VfaRrup",
+      "hash": "QmSbvata2WqNkqGtZNg8MR3SKwnB8iQ7vTPJgWqB8bC5kR",
       "name": "go-multibase",
-      "version": "0.2.6"
+      "version": "0.2.7"
     }
   ],
   "gxVersion": "0.8.0",

--- a/set.go
+++ b/set.go
@@ -12,18 +12,18 @@ func NewSet() *Set {
 }
 
 // Add puts a Cid in the Set.
-func (s *Set) Add(c *Cid) {
+func (s *Set) Add(c Cid) {
 	s.set[string(c.Bytes())] = struct{}{}
 }
 
 // Has returns if the Set contains a given Cid.
-func (s *Set) Has(c *Cid) bool {
+func (s *Set) Has(c Cid) bool {
 	_, ok := s.set[string(c.Bytes())]
 	return ok
 }
 
 // Remove deletes a Cid from the Set.
-func (s *Set) Remove(c *Cid) {
+func (s *Set) Remove(c Cid) {
 	delete(s.set, string(c.Bytes()))
 }
 
@@ -33,8 +33,8 @@ func (s *Set) Len() int {
 }
 
 // Keys returns the Cids in the set.
-func (s *Set) Keys() []*Cid {
-	out := make([]*Cid, 0, len(s.set))
+func (s *Set) Keys() []Cid {
+	out := make([]Cid, 0, len(s.set))
 	for k := range s.set {
 		c, _ := Cast([]byte(k))
 		out = append(out, c)
@@ -44,7 +44,7 @@ func (s *Set) Keys() []*Cid {
 
 // Visit adds a Cid to the set only if it is
 // not in it already.
-func (s *Set) Visit(c *Cid) bool {
+func (s *Set) Visit(c Cid) bool {
 	if !s.Has(c) {
 		s.Add(c)
 		return true
@@ -55,7 +55,7 @@ func (s *Set) Visit(c *Cid) bool {
 
 // ForEach allows to run a custom function on each
 // Cid in the set.
-func (s *Set) ForEach(f func(c *Cid) error) error {
+func (s *Set) ForEach(f func(c Cid) error) error {
 	for cs := range s.set {
 		c, _ := Cast([]byte(cs))
 		err := f(c)

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,90 @@
+package cid
+
+import (
+	"fmt"
+	"testing"
+
+	mh "github.com/multiformats/go-multihash"
+)
+
+func makeCid(i int) Cid {
+	data := []byte(fmt.Sprintf("this is some test content %d", i))
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	return NewCidV1(Raw, hash)
+}
+
+func TestSetRemove(t *testing.T) {
+	s := NewSet()
+
+	c1 := makeCid(1)
+	s.Add(c1)
+
+	if !s.Has(c1) {
+		t.Fatal("failed to add cid")
+	}
+
+	s.Remove(c1)
+	if s.Has(c1) {
+		t.Fatal("failed to remove cid")
+	}
+
+	// make sure this doesn't fail, removing a removed one
+	s.Remove(c1)
+}
+
+func BenchmarkSetVisit(b *testing.B) {
+	s := NewSet()
+
+	cids := make([]Cid, b.N)
+	for i := 0; i < b.N; i++ {
+		cids[i] = makeCid(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		s.Visit(cids[i])
+		// twice to ensure we test the adding of an existing element
+		s.Visit(cids[i])
+	}
+	if s.Len() != b.N {
+		b.FailNow()
+	}
+}
+
+func BenchmarkStringV1(b *testing.B) {
+	data := []byte("this is some test content")
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	cid := NewCidV1(Raw, hash)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	count := 0
+	for i := 0; i < b.N; i++ {
+		count += len(cid.String())
+	}
+	if count != 49*b.N {
+		b.FailNow()
+	}
+}
+
+// making sure we don't allocate when returning bytes
+func BenchmarkBytesV1(b *testing.B) {
+	data := []byte("this is some test content")
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	cid := NewCidV1(Raw, hash)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	count := 0
+	for i := 0; i < b.N; i++ {
+		count += len(cid.Bytes())
+		count += len([]byte(cid))
+	}
+	if count != 36*2*b.N {
+		b.FailNow()
+	}
+}


### PR DESCRIPTION
This builds on #47 but instead makes the `Cid` type an interface.  I was initially against the idea but then realized that it will help with the switch to `base32` by allowing a base to be stored with a Cid, so that when it converted back to a string the same base can be used.

This creates two new types that can be used directly: (1) `CidString` a string that is the binary representation of a Cid.  This type can be used directly in Maps and when the additional overhead of an interface creates performance problems.  (2) `CidWithBase` a Cid with a multibase associated with it.  Calling String() will reencode CidV1 using that base.

This will still break code as `*cid.Cid` will need to change to `cid.Cid` but it should be less painful (as nil can still be used) and only needs to be done once.