### PR TITLE
add codecs for Dash blocks, tx

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -79,6 +79,8 @@ const (
 	ZcashTx            = 0xc1
 	DecredBlock        = 0xe0
 	DecredTx           = 0xe1
+	DashBlock          = 0xf0
+	DashTx             = 0xf1
 )
 
 // Codecs maps the name of a codec to its type
@@ -103,6 +105,8 @@ var Codecs = map[string]uint64{
 	"zcash-tx":             ZcashTx,
 	"decred-block":         DecredBlock,
 	"decred-tx":            DecredTx,
+	"dash-block":           DashBlock,
+	"dash-tx":              DashTx,
 }
 
 // CodecToStr maps the numeric codec to its name
@@ -126,6 +130,8 @@ var CodecToStr = map[uint64]string{
 	ZcashTx:            "zcash-tx",
 	DecredBlock:        "decred-block",
 	DecredTx:           "decred-tx",
+	DashBlock:          "dash-block",
+	DashTx:             "dash-tx",
 }
 
 // NewCidV0 returns a Cid-wrapped multihash.

--- a/cid_test.go
+++ b/cid_test.go
@@ -35,6 +35,8 @@ var tCodecs = map[uint64]string{
 	ZcashTx:            "zcash-tx",
 	DecredBlock:        "decred-block",
 	DecredTx:           "decred-tx",
+	DashBlock:          "dash-block",
+	DashTx:             "dash-tx",
 }
 
 func assertEqual(t *testing.T, a, b Cid) {


### PR DESCRIPTION
This is dependent upon https://github.com/multiformats/multicodec/pull/86 being merged in, and is needed for the Dash IPLD Resolver https://github.com/samli88/go-ipld-dash/tree/dash.