### PR TITLE
Let Cid implement Binary[Un]Marshaler and Text[Un]Marshaler interfaces.

### DIFF
--- a/cid_test.go
+++ b/cid_test.go
@@ -158,6 +158,44 @@ func TestBasesMarshaling(t *testing.T) {
 	}
 }
 
+func TestBinaryMarshaling(t *testing.T) {
+	data := []byte("this is some test content")
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	c := NewCidV1(DagCBOR, hash)
+	var c2 Cid
+
+	data, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c2.UnmarshalBinary(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Equals(c2) {
+		t.Errorf("cids should be the same: %s %s", c, c2)
+	}
+}
+
+func TestTextMarshaling(t *testing.T) {
+	data := []byte("this is some test content")
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	c := NewCidV1(DagCBOR, hash)
+	var c2 Cid
+
+	data, err := c.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c2.UnmarshalText(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Equals(c2) {
+		t.Errorf("cids should be the same: %s %s", c, c2)
+	}
+}
+
 func TestEmptyString(t *testing.T) {
 	_, err := Decode("")
 	if err == nil {


### PR DESCRIPTION
This makes Cid implement https://golang.org/pkg/encoding/#BinaryMarshaler
which is used by go-codec to decide if things know how to serialize themselves
(currently we need do manual wrapping for anything containing a CID).

Since I was at it, I did the TextMarshaling one too.