### PR TITLE
Add support for libp2p-key multicodec to go-cid

### DIFF
--- a/_rsrch/cidiface/enums.go
+++ b/_rsrch/cidiface/enums.go
@@ -8,6 +8,7 @@ const (
 
 	DagProtobuf = 0x70
 	DagCBOR     = 0x71
+	Libp2pKey   = 0x72
 
 	GitRaw = 0x78
 
@@ -34,6 +35,7 @@ var Codecs = map[string]uint64{
 	"raw":                  Raw,
 	"protobuf":             DagProtobuf,
 	"cbor":                 DagCBOR,
+	"libp2p-key":           Libp2pKey,
 	"git-raw":              GitRaw,
 	"eth-block":            EthBlock,
 	"eth-block-list":       EthBlockList,
@@ -57,6 +59,7 @@ var CodecToStr = map[uint64]string{
 	Raw:                "raw",
 	DagProtobuf:        "protobuf",
 	DagCBOR:            "cbor",
+	Libp2pKey:          "libp2p-key",
 	GitRaw:             "git-raw",
 	EthBlock:           "eth-block",
 	EthBlockList:       "eth-block-list",

--- a/cid.go
+++ b/cid.go
@@ -62,6 +62,7 @@ const (
 
 	DagProtobuf = 0x70
 	DagCBOR     = 0x71
+	Libp2pKey   = 0x72
 
 	GitRaw = 0x78
 
@@ -90,6 +91,7 @@ var Codecs = map[string]uint64{
 	"raw":                  Raw,
 	"protobuf":             DagProtobuf,
 	"cbor":                 DagCBOR,
+	"libp2p-key":           Libp2pKey,
 	"git-raw":              GitRaw,
 	"eth-block":            EthBlock,
 	"eth-block-list":       EthBlockList,

--- a/cid_test.go
+++ b/cid_test.go
@@ -19,6 +19,7 @@ var tCodecs = map[uint64]string{
 	Raw:                "raw",
 	DagProtobuf:        "protobuf",
 	DagCBOR:            "cbor",
+	Libp2pKey:          "libp2p-key",
 	GitRaw:             "git-raw",
 	EthBlock:           "eth-block",
 	EthBlockList:       "eth-block-list",


### PR DESCRIPTION
Context: https://github.com/multiformats/multicodec/issues/130

This PR updates the multicodec table to match the latest [`multiformats/multicodec/table.csv`](https://github.com/multiformats/multicodec/blob/master/table.csv)

-  `libp2p-key` added in https://github.com/multiformats/multicodec/issues/130
    - First step to support `https://<libp2p-key-in-cidv1b32>.ipns.dweb.link` – https://github.com/ipfs/go-ipfs/issues/5287

cc https://github.com/ipfs/go-ipfs/issues/5287, https://github.com/ipfs/ipfs/issues/337, @Stebalien, @hsanjuan  

