### PR TITLE
chore: make comment reflect the code

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -337,8 +337,8 @@ func (c Cid) Type() uint64 {
 }
 
 // String returns the default string representation of a
-// Cid. Currently, Base58 is used as the encoding for the
-// multibase string.
+// Cid. Currently, Base32 is used for CIDV1 as the encoding for the
+// multibase string, Base58 is used for CIDV0.
 func (c Cid) String() string {
 	switch c.Version() {
 	case 0:


### PR DESCRIPTION
During the change to default CIDV1 to Base32, the corresponding code
comment wasn't updated.