### PR TITLE
Fix inaccurate comment for uvarint

### DIFF
--- a/varint.go
+++ b/varint.go
@@ -12,7 +12,7 @@ import (
 // license as given at https://golang.org/LICENSE
 
 // uvarint decodes a uint64 from buf and returns that value and the
-// number of characters read (> 0). If an error occurred, then 0 is
+// number of bytes read (> 0). If an error occurred, then 0 is
 // returned for both the value and the number of bytes read, and an
 // error is returned.
 func uvarint(buf string) (uint64, int, error) {

--- a/varint.go
+++ b/varint.go
@@ -4,7 +4,7 @@ import (
 	"github.com/multiformats/go-varint"
 )
 
-// Version of varint function that work with a string rather than
+// Version of varint function that works with a string rather than
 // []byte to avoid unnecessary allocation
 
 // Copyright 2011 The Go Authors. All rights reserved.
@@ -12,23 +12,20 @@ import (
 // license as given at https://golang.org/LICENSE
 
 // uvarint decodes a uint64 from buf and returns that value and the
-// number of characters read (> 0). If an error occurred, the value is 0
-// and the number of bytes n is <= 0 meaning:
-//
-// 	n == 0: buf too small
-// 	n  < 0: value larger than 64 bits (overflow)
-// 	        and -n is the number of bytes read
-//
+// number of characters read (> 0). If an error occurred, then 0 is
+// returned for both the value and the number of bytes read, and an
+// error is returned.
 func uvarint(buf string) (uint64, int, error) {
 	var x uint64
 	var s uint
-	// we have a binary string so we can't use a range loope
+	// we have a binary string so we can't use a range loop
 	for i := 0; i < len(buf); i++ {
 		b := buf[i]
 		if b < 0x80 {
 			if i > 9 || i == 9 && b > 1 {
 				return 0, 0, varint.ErrOverflow
-			} else if b == 0 && i > 0 {
+			}
+			if b == 0 && i > 0 {
 				return 0, 0, varint.ErrNotMinimal
 			}
 			return x | uint64(b)<<s, i + 1, nil


### PR DESCRIPTION
This fixes the comment to be consistent with the code, and fixes spelling.

Fixes Issue #111