### PR TITLE
fix: make tests run with Go 1.5

### DIFF
--- a/cid_test.go
+++ b/cid_test.go
@@ -448,7 +448,7 @@ func TestParse(t *testing.T) {
 			return err
 		}
 		if cid.Version() != 0 {
-			return fmt.Errorf("expected version 0, got %s", string(cid.Version()))
+			return fmt.Errorf("expected version 0, got %s", fmt.Sprintf("%d", cid.Version()))
 		}
 		actual := cid.Hash().B58String()
 		if actual != expected {


### PR DESCRIPTION
> ./cid_test.go:451:52: conversion from uint64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)

Review please, @mvdan?