### PR TITLE
fix: improved error message on broken CIDv0

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -254,6 +254,9 @@ func Decode(v string) (Cid, error) {
 
 	_, data, err := mbase.Decode(v)
 	if err != nil {
+		if len(v) == 46 && v[:2] == "qm" { // https://github.com/ipfs/go-ipfs/issues/7792
+			return Undef, fmt.Errorf("%v: This looks like a CIDv0 that has been lowercased. Convert the CIDv0 to CIDv1 in case-insensitive base32 using 'ipfs cid base32 <Qm..>' and try again.", err)
+		}
 		return Undef, err
 	}
 

--- a/cid_test.go
+++ b/cid_test.go
@@ -332,6 +332,17 @@ func TestV0ErrorCases(t *testing.T) {
 	}
 }
 
+func TestV0ErrorDueToLowercase(t *testing.T) {
+	badb58 := "qmbwqxbekc3p8tqskc98xmwnzrzdtrlmimpl8wbutgsmnr"
+	_, err := Decode(badb58)
+	if err == nil {
+		t.Fatal("should have failed to decode")
+	}
+	if !strings.HasSuffix(err.Error(), "This looks like a CIDv0 that has been lowercased. Convert the CIDv0 to CIDv1 in case-insensitive base32 using 'ipfs cid base32 <Qm..>' and try again.") {
+		t.Fatal("should have meaningful info about case-insensitive fix")
+	}
+}
+
 func TestNewPrefixV1(t *testing.T) {
 	data := []byte("this is some test content")
 


### PR DESCRIPTION
This aims to close DX/UX issue described in https://github.com/ipfs/go-ipfs/issues/7792

### Before

`invalid path "/ipfs/qmbwqxbekc3p8tqskc98xmwnzrzdtrlmimpl8wbutgsmnr/": invalid CID: selected encoding not supported`

### After

`invalid path "/ipfs/qmbwqxbekc3p8tqskc98xmwnzrzdtrlmimpl8wbutgsmnr/": invalid CID: selected encoding not supported: This looks like a CIDv0 that has been lowercased. Convert the CIDv0 to CIDv1 in case-insensitive base32 using 'ipfs cid base32 <Qm..>' and try again.`