### PR TITLE
CI config: update golang version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.11.x
+  - 1.15.x
 
 env:
   global:


### PR DESCRIPTION
This will become relevant when I bump the go-multihash dependency
in a moment, because that repo now uses golang stdlib features
that are from a relatively modern era.

(Go 1.11 is a *long* time ago now.)

This is a fairly boring change, so I'm going to merge it immediately as soon as CI confirms it's in fact fine.