### PR TITLE
refactor: remove invalid string2code mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,17 @@ fmt.Println("Got CID: ", c)
 #### Creating a CID from scratch
 
 ```go
+
+import (
+  cid "github.com/ipfs/go-cid"
+  mc "github.com/multiformats/go-multicodec"
+  mh "github.com/multiformats/go-multihash"
+)
+
 // Create a cid manually by specifying the 'prefix' parameters
 pref := cid.Prefix{
 	Version: 1,
-	Codec: cid.Raw,
+	Codec: mc.Raw,
 	MhType: mh.SHA2_256,
 	MhLength: -1, // default length
 }

--- a/cid.go
+++ b/cid.go
@@ -58,15 +58,9 @@ const (
 	DagJSON     = 0x0129 // https://ipld.io/docs/codecs/known/dag-json/
 	Libp2pKey   = 0x72   // https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids
 
-	// generic, non-dag variants
-	Protobuf = 0x50
-	CBOR     = 0x51
-	JSON     = 0x0200
-
 	// other
 	GitRaw                = 0x78
 	DagJOSE               = 0x85 // https://ipld.io/specs/codecs/dag-jose/spec/
-	DagCOSE               = 0x86
 	EthBlock              = 0x90
 	EthBlockList          = 0x91
 	EthTxTrie             = 0x92
@@ -87,75 +81,6 @@ const (
 	FilCommitmentUnsealed = 0xf101
 	FilCommitmentSealed   = 0xf102
 )
-
-// Codecs maps the name of a codec to its type
-var Codecs = map[string]uint64{
-	"v0":                      DagProtobuf, // TODO: remove?
-	"raw":                     Raw,
-	"dag-pb":                  DagProtobuf,
-	"dag-cbor":                DagCBOR,
-	"dag-json":                DagJSON,
-	"libp2p-key":              Libp2pKey,
-	"protobuf":                Protobuf,
-	"cbor":                    CBOR,
-	"json":                    JSON,
-	"git-raw":                 GitRaw,
-	"eth-block":               EthBlock,
-	"eth-block-list":          EthBlockList,
-	"eth-tx-trie":             EthTxTrie,
-	"eth-tx":                  EthTx,
-	"eth-tx-receipt-trie":     EthTxReceiptTrie,
-	"eth-tx-receipt":          EthTxReceipt,
-	"eth-state-trie":          EthStateTrie,
-	"eth-account-snapshot":    EthAccountSnapshot,
-	"eth-storage-trie":        EthStorageTrie,
-	"bitcoin-block":           BitcoinBlock,
-	"bitcoin-tx":              BitcoinTx,
-	"zcash-block":             ZcashBlock,
-	"zcash-tx":                ZcashTx,
-	"decred-block":            DecredBlock,
-	"decred-tx":               DecredTx,
-	"dash-block":              DashBlock,
-	"dash-tx":                 DashTx,
-	"fil-commitment-unsealed": FilCommitmentUnsealed,
-	"fil-commitment-sealed":   FilCommitmentSealed,
-	"dag-jose":                DagJOSE,
-	"dag-cose":                DagCOSE,
-}
-
-// CodecToStr maps the numeric codec to its name
-var CodecToStr = map[uint64]string{
-	Raw:                   "raw",
-	DagProtobuf:           "dag-pb",
-	DagCBOR:               "dag-cbor",
-	DagJSON:               "dag-json",
-	Libp2pKey:             "libp2p-key",
-	Protobuf:              "protobuf",
-	CBOR:                  "cbor",
-	JSON:                  "json",
-	GitRaw:                "git-raw",
-	EthBlock:              "eth-block",
-	EthBlockList:          "eth-block-list",
-	EthTxTrie:             "eth-tx-trie",
-	EthTx:                 "eth-tx",
-	EthTxReceiptTrie:      "eth-tx-receipt-trie",
-	EthTxReceipt:          "eth-tx-receipt",
-	EthStateTrie:          "eth-state-trie",
-	EthAccountSnapshot:    "eth-account-snapshot",
-	EthStorageTrie:        "eth-storage-trie",
-	BitcoinBlock:          "bitcoin-block",
-	BitcoinTx:             "bitcoin-tx",
-	ZcashBlock:            "zcash-block",
-	ZcashTx:               "zcash-tx",
-	DecredBlock:           "decred-block",
-	DecredTx:              "decred-tx",
-	DashBlock:             "dash-block",
-	DashTx:                "dash-tx",
-	FilCommitmentUnsealed: "fil-commitment-unsealed",
-	FilCommitmentSealed:   "fil-commitment-sealed",
-	DagJOSE:               "dag-jose",
-	DagCOSE:               "dag-cose",
-}
 
 // tryNewCidV0 tries to convert a multihash into a CIDv0 CID and returns an
 // error on failure.

--- a/cid.go
+++ b/cid.go
@@ -51,15 +51,22 @@ var (
 // the codes described in the authoritative document:
 // https://github.com/multiformats/multicodec/blob/master/table.csv
 const (
-	Raw = 0x55
+	// core IPLD
+	Raw         = 0x55
+	DagProtobuf = 0x70   // https://ipld.io/docs/codecs/known/dag-pb/
+	DagCBOR     = 0x71   // https://ipld.io/docs/codecs/known/dag-cbor/
+	DagJSON     = 0x0129 // https://ipld.io/docs/codecs/known/dag-json/
+	Libp2pKey   = 0x72   // https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids
 
-	DagProtobuf = 0x70
-	DagCBOR     = 0x71
-	Libp2pKey   = 0x72
+	// generic, non-dag variants
+	Protobuf = 0x50
+	CBOR     = 0x51
+	JSON     = 0x0200
 
-	GitRaw = 0x78
-
-	DagJOSE               = 0x85
+	// other
+	GitRaw                = 0x78
+	DagJOSE               = 0x85 // https://ipld.io/specs/codecs/dag-jose/spec/
+	DagCOSE               = 0x86
 	EthBlock              = 0x90
 	EthBlockList          = 0x91
 	EthTxTrie             = 0x92
@@ -83,11 +90,15 @@ const (
 
 // Codecs maps the name of a codec to its type
 var Codecs = map[string]uint64{
-	"v0":                      DagProtobuf,
+	"v0":                      DagProtobuf, // TODO: remove?
 	"raw":                     Raw,
-	"protobuf":                DagProtobuf,
-	"cbor":                    DagCBOR,
+	"dag-pb":                  DagProtobuf,
+	"dag-cbor":                DagCBOR,
+	"dag-json":                DagJSON,
 	"libp2p-key":              Libp2pKey,
+	"protobuf":                Protobuf,
+	"cbor":                    CBOR,
+	"json":                    JSON,
 	"git-raw":                 GitRaw,
 	"eth-block":               EthBlock,
 	"eth-block-list":          EthBlockList,
@@ -109,13 +120,19 @@ var Codecs = map[string]uint64{
 	"fil-commitment-unsealed": FilCommitmentUnsealed,
 	"fil-commitment-sealed":   FilCommitmentSealed,
 	"dag-jose":                DagJOSE,
+	"dag-cose":                DagCOSE,
 }
 
 // CodecToStr maps the numeric codec to its name
 var CodecToStr = map[uint64]string{
 	Raw:                   "raw",
-	DagProtobuf:           "protobuf",
-	DagCBOR:               "cbor",
+	DagProtobuf:           "dag-pb",
+	DagCBOR:               "dag-cbor",
+	DagJSON:               "dag-json",
+	Libp2pKey:             "libp2p-key",
+	Protobuf:              "protobuf",
+	CBOR:                  "cbor",
+	JSON:                  "json",
 	GitRaw:                "git-raw",
 	EthBlock:              "eth-block",
 	EthBlockList:          "eth-block-list",
@@ -137,6 +154,7 @@ var CodecToStr = map[uint64]string{
 	FilCommitmentUnsealed: "fil-commitment-unsealed",
 	FilCommitmentSealed:   "fil-commitment-sealed",
 	DagJOSE:               "dag-jose",
+	DagCOSE:               "dag-cose",
 }
 
 // tryNewCidV0 tries to convert a multihash into a CIDv0 CID and returns an

--- a/cid.go
+++ b/cid.go
@@ -47,11 +47,12 @@ var (
 	ErrInvalidEncoding = errors.New("invalid base encoding")
 )
 
-// These are multicodec-packed content types. The should match
-// the codes described in the authoritative document:
-// https://github.com/multiformats/multicodec/blob/master/table.csv
+// Consts below are DEPRECATED and left only for legacy reasons:
+// <https://github.com/ipfs/go-cid/pull/137>
+// Modern code should use consts from go-multicodec instead:
+// <https://github.com/multiformats/go-multicodec>
 const (
-	// core IPLD
+	// common ones
 	Raw         = 0x55
 	DagProtobuf = 0x70   // https://ipld.io/docs/codecs/known/dag-pb/
 	DagCBOR     = 0x71   // https://ipld.io/docs/codecs/known/dag-cbor/

--- a/cid_test.go
+++ b/cid_test.go
@@ -20,9 +20,13 @@ import (
 // Makes it so changing the table accidentally has to happen twice.
 var tCodecs = map[uint64]string{
 	Raw:                   "raw",
-	DagProtobuf:           "protobuf",
-	DagCBOR:               "cbor",
+	DagProtobuf:           "dag-pb",
+	DagCBOR:               "dag-cbor",
+	DagJSON:               "dag-json",
 	Libp2pKey:             "libp2p-key",
+	Protobuf:              "protobuf",
+	CBOR:                  "cbor",
+	JSON:                  "json",
 	GitRaw:                "git-raw",
 	EthBlock:              "eth-block",
 	EthBlockList:          "eth-block-list",
@@ -44,6 +48,7 @@ var tCodecs = map[uint64]string{
 	FilCommitmentUnsealed: "fil-commitment-unsealed",
 	FilCommitmentSealed:   "fil-commitment-sealed",
 	DagJOSE:               "dag-jose",
+	DagCOSE:               "dag-cose",
 }
 
 func assertEqual(t *testing.T, a, b Cid) {

--- a/cid_test.go
+++ b/cid_test.go
@@ -15,42 +15,6 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-// Copying the "silly test" idea from
-// https://github.com/multiformats/go-multihash/blob/7aa9f26a231c6f34f4e9fad52bf580fd36627285/multihash_test.go#L13
-// Makes it so changing the table accidentally has to happen twice.
-var tCodecs = map[uint64]string{
-	Raw:                   "raw",
-	DagProtobuf:           "dag-pb",
-	DagCBOR:               "dag-cbor",
-	DagJSON:               "dag-json",
-	Libp2pKey:             "libp2p-key",
-	Protobuf:              "protobuf",
-	CBOR:                  "cbor",
-	JSON:                  "json",
-	GitRaw:                "git-raw",
-	EthBlock:              "eth-block",
-	EthBlockList:          "eth-block-list",
-	EthTxTrie:             "eth-tx-trie",
-	EthTx:                 "eth-tx",
-	EthTxReceiptTrie:      "eth-tx-receipt-trie",
-	EthTxReceipt:          "eth-tx-receipt",
-	EthStateTrie:          "eth-state-trie",
-	EthAccountSnapshot:    "eth-account-snapshot",
-	EthStorageTrie:        "eth-storage-trie",
-	BitcoinBlock:          "bitcoin-block",
-	BitcoinTx:             "bitcoin-tx",
-	ZcashBlock:            "zcash-block",
-	ZcashTx:               "zcash-tx",
-	DecredBlock:           "decred-block",
-	DecredTx:              "decred-tx",
-	DashBlock:             "dash-block",
-	DashTx:                "dash-tx",
-	FilCommitmentUnsealed: "fil-commitment-unsealed",
-	FilCommitmentSealed:   "fil-commitment-sealed",
-	DagJOSE:               "dag-jose",
-	DagCOSE:               "dag-cose",
-}
-
 func assertEqual(t *testing.T, a, b Cid) {
 	if a.Type() != b.Type() {
 		t.Fatal("mismatch on type")
@@ -62,26 +26,6 @@ func assertEqual(t *testing.T, a, b Cid) {
 
 	if !bytes.Equal(a.Hash(), b.Hash()) {
 		t.Fatal("multihash mismatch")
-	}
-}
-
-func TestTable(t *testing.T) {
-	if len(tCodecs) != len(Codecs)-1 {
-		t.Errorf("Item count mismatch in the Table of Codec. Should be %d, got %d", len(tCodecs)+1, len(Codecs))
-	}
-
-	for k, v := range tCodecs {
-		if Codecs[v] != k {
-			t.Errorf("Table mismatch: 0x%x %s", k, v)
-		}
-	}
-}
-
-// The table returns cid.DagProtobuf for "v0"
-// so we test it apart
-func TestTableForV0(t *testing.T) {
-	if Codecs["v0"] != DagProtobuf {
-		t.Error("Table mismatch: Codecs[\"v0\"] should resolve to DagProtobuf (0x70)")
 	}
 }
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.0"
+  "version": "v0.2.0"
 }


### PR DESCRIPTION
## Problem: string2codec maps are a mess

The current state is not sustainable, string mappings are invalid or missing, and we don't have correct ones for core IPLD formats like `dag-pb`, `dag-json` and `dag-cbor` :see_no_evil: 

Solution: cleanup

## Problem 2: cleanup may introduce silent bugs into people's codebases

https://github.com/ipfs/go-cid/pull/137/commits/da5524780a4ae73d6b2ca765f1df8e7e8b7b0bcd  demonstrates the map changes we would have to do to restore sanity:  fixes mapping, and adds IPLD formats along with non-dag generic variants for Protobuf, JSON and   CBOR, so go-cid finally match the [source of truth](https://github.com/multiformats/multicodec/blob/master/table.csv).

This approach would change the meaning of code `0x70` and `0x71` and strings `cbor` and `protobuf`:

- `protobuf` string now correctly points at code `0x50`  (was `0x70`, which is  `dag-pb`)
  -  `0x70` code is mapped to `dag-pb` (was `protobuf` before)
- `cbor` string now correctly points at code `0x51` (was `0x71`, which is  `dag-cbor`)
  - `0x71` code is now mapped to `dag-cbor` (was `cbor` before)
  
Pretty risky – people dont read release notes, this could cause silent errors in people's software.
Also, we have proper code2string mappings in  [go-multicodec](https://github.com/multiformats/go-multicodec)  (generated, and not written by hand)

# Solution

Remove invalid/redundant string2code mappings from go-ipfs, point ecosystem at using go-multicodec directly.

# BREAKING CHANGE
  
  
## Implemented Approach B: Remove invalid mappings entirely :green_heart: 

I applied this in https://github.com/ipfs/go-cid/pull/137/commits/6ca2617460d553e1aa10d4fdced1dcfedd300197

We already have [go-multicodec](https://github.com/multiformats/go-multicodec) which is generated from the [source of truth](https://github.com/multiformats/multicodec/blob/master/table.csv).

We remove hardcoded maps, then people will be forced to refactor their code to use  go-multicodec (https://github.com/multiformats/go-multicodec/issues/65) – forcing people to refactor makes it less likely they will just blindly bump the dependency without reading release notes.

----

# Refactor guide

Converting  code to string and vice versa will no longer be done with go-cid, go-multicodec should be used instead

## Old  way (go-cid)

```go

cid "github.com/ipfs/go-cid"

// string → code
code := cid.Codecs["libp2p-key"]

// code → string
string := cid.CodecToStr[code]
```

## New way (go-multicodec)


```go
mc "github.com/multiformats/go-multicodec"

// string → code
var mc.Code code 
code.Set("libp2p-key")

// code → string
code.String()
```
