### PR TITLE
fix: bring back, but deprecate CodecToStr and Codecs

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	mbase "github.com/multiformats/go-multibase"
+	"github.com/multiformats/go-multicodec"
 	mh "github.com/multiformats/go-multihash"
 	varint "github.com/multiformats/go-varint"
 )
@@ -82,6 +83,25 @@ const (
 	FilCommitmentUnsealed = 0xf101
 	FilCommitmentSealed   = 0xf102
 )
+
+// Codecs maps the name of a codec to its type
+// Deprecated: modern code should use consts from go-multicodec instead:
+// <https://github.com/multiformats/go-multicodec>
+var Codecs map[string]uint64
+
+// CodecToStr maps the numeric codec to its name
+// Deprecated: modern code should use consts from go-multicodec instead:
+// <https://github.com/multiformats/go-multicodec>
+var CodecToStr map[uint64]string
+
+func init() {
+	Codecs = make(map[string]uint64)
+	CodecToStr = make(map[uint64]string)
+	for _, code := range multicodec.KnownCodes() {
+		Codecs[code.String()] = uint64(code)
+		CodecToStr[uint64(code)] = code.String()
+	}
+}
 
 // tryNewCidV0 tries to convert a multihash into a CIDv0 CID and returns an
 // error on failure.

--- a/cid_test.go
+++ b/cid_test.go
@@ -29,6 +29,43 @@ func assertEqual(t *testing.T, a, b Cid) {
 	}
 }
 
+func TestTable(t *testing.T) {
+	// test some known codecs, hard-wired here to make them a fixture that would
+	// need to be updated if they change elsewhere
+	for k, v := range map[uint64]string{
+		Raw:                   "raw",
+		DagProtobuf:           "dag-pb",
+		DagCBOR:               "dag-cbor",
+		DagJSON:               "dag-json",
+		Libp2pKey:             "libp2p-key",
+		GitRaw:                "git-raw",
+		EthBlock:              "eth-block",
+		EthBlockList:          "eth-block-list",
+		EthTxTrie:             "eth-tx-trie",
+		EthTx:                 "eth-tx",
+		EthTxReceiptTrie:      "eth-tx-receipt-trie",
+		EthTxReceipt:          "eth-tx-receipt",
+		EthStateTrie:          "eth-state-trie",
+		EthAccountSnapshot:    "eth-account-snapshot",
+		EthStorageTrie:        "eth-storage-trie",
+		BitcoinBlock:          "bitcoin-block",
+		BitcoinTx:             "bitcoin-tx",
+		ZcashBlock:            "zcash-block",
+		ZcashTx:               "zcash-tx",
+		DecredBlock:           "decred-block",
+		DecredTx:              "decred-tx",
+		DashBlock:             "dash-block",
+		DashTx:                "dash-tx",
+		FilCommitmentUnsealed: "fil-commitment-unsealed",
+		FilCommitmentSealed:   "fil-commitment-sealed",
+		DagJOSE:               "dag-jose",
+	} {
+		if Codecs[v] != k {
+			t.Errorf("Table mismatch: 0x%x %s", k, v)
+		}
+	}
+}
+
 func TestPrefixSum(t *testing.T) {
 	// Test creating CIDs both manually and with Prefix.
 	// Tests: https://github.com/ipfs/go-cid/issues/83

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/ipfs/go-cid
 
 require (
 	github.com/multiformats/go-multibase v0.0.3
+	github.com/multiformats/go-multicodec v0.5.0
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/multiformats/go-varint v0.0.6
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ8
 github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multicodec v0.5.0 h1:EgU6cBe/D7WRwQb1KmnBvU7lrcFGMggZVTPtOW9dDHs=
+github.com/multiformats/go-multicodec v0.5.0/go.mod h1:DiY2HFaEp5EhEXb/iYzVAunmyX/aSFMxq2KMKfWEues=
 github.com/multiformats/go-multihash v0.0.15 h1:hWOPdrNqDjwHDx82vsYGSDZNyktOJJ2dzZJzFkOV1jM=
 github.com/multiformats/go-multihash v0.0.15/go.mod h1:D6aZrWNLFTV/ynMpKsNtB40mJzmCl4jb1alC0OvHiHg=
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.0"
+  "version": "v0.3.1"
 }


### PR DESCRIPTION
Uses go-multicodec as the source of truth this time.

So ... I think I want to assert that we made a mistake in https://github.com/ipfs/go-cid/pull/137 by removing it entirely. It continues to be a source of pain across our whole Go ecosystem of packages - primarily coming from the github.com/libp2p/go-libp2p-core usage of it in its `FromCid()`. Now, upgrading dependencies means following up a whole chain of (often unrelated) dependencies just to get libp2p upgraded. My latest instance of this is in trying to get some basic deps upgraded in go-merkledag, which shouldn't care about libp2p but does for some transitive dependencies in some test things. Ultimately that goes back to needing to upgrade go-bitswap's libp2p dependencies .. which I really don't want to have to go just to get go-merkledag upgraded.

This time, we're deferring to go-multicodec for the mappings, and I'd like to get dependabot setup here too to make sure we keep that updated. There's also a deprecation notice which at least staticcheck should pick up.

I think, in lieu of proper semver-major semantics, this is playing like a good open source semver citizen, moreso than just yanking it out? Maybe next time for something like this we can bite the bullet and semver-major bump.