### PR TITLE
perf: add a generic CID type which allows for aliased byte slices

### DIFF
--- a/cid.go
+++ b/cid.go
@@ -607,6 +607,11 @@ func (c CidOf[S]) Prefix() Prefix {
 	}
 }
 
+// Append appends the cid to some slice of bytes.
+func (c CidOf[S]) Append(in []byte) []byte {
+	return append(in, c.storage...)
+}
+
 // Prefix represents all the metadata of a Cid,
 // that is, the Version, the Codec, the Multihash type
 // and the Multihash length. It does not contains

--- a/varint.go
+++ b/varint.go
@@ -15,7 +15,7 @@ import (
 // number of bytes read (> 0). If an error occurred, then 0 is
 // returned for both the value and the number of bytes read, and an
 // error is returned.
-func uvarint(buf string) (uint64, int, error) {
+func uvarint[S Storage](buf S) (uint64, int, error) {
 	var x uint64
 	var s uint
 	// we have a binary string so we can't use a range loop


### PR DESCRIPTION
This is backward  compatible (that why I hacked it with generics).
I should probably make generic versions of the builders too.

Results:
```
name   old time/op    new time/op    delta
PB-12     730ns ± 5%     255ns ± 2%   -65.04%  (p=0.000 n=9+10)

name   old alloc/op   new alloc/op   delta
PB-12      224B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name   old allocs/op  new allocs/op  delta
PB-12      4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```